### PR TITLE
Add 'as any' to work around union/mutation bug.

### DIFF
--- a/integration/graphql-types.tsx
+++ b/integration/graphql-types.tsx
@@ -391,7 +391,8 @@ export function newGetAuthorSummariesResponse(
 ): MockedResponse<GetAuthorSummariesQueryVariables, GetAuthorSummariesQuery> {
   return {
     request: { query: GetAuthorSummariesDocument },
-    result: { data: data instanceof Error ? undefined : newGetAuthorSummariesData(data) },
+    // TODO Remove the any by having interfaces have a __typename that pacifies mutation type unions
+    result: { data: data instanceof Error ? undefined : (newGetAuthorSummariesData(data) as any) },
     error: data instanceof Error ? data : undefined,
   };
 }
@@ -412,7 +413,8 @@ export function newSaveAuthorResponse(
 ): MockedResponse<SaveAuthorMutationVariables, SaveAuthorMutation> {
   return {
     request: { query: SaveAuthorDocument, variables },
-    result: { data: data instanceof Error ? undefined : newSaveAuthorData(data) },
+    // TODO Remove the any by having interfaces have a __typename that pacifies mutation type unions
+    result: { data: data instanceof Error ? undefined : (newSaveAuthorData(data) as any) },
     error: data instanceof Error ? data : undefined,
   };
 }
@@ -432,7 +434,8 @@ export function newCurrentAuthorResponse(
 ): MockedResponse<CurrentAuthorQueryVariables, CurrentAuthorQuery> {
   return {
     request: { query: CurrentAuthorDocument },
-    result: { data: data instanceof Error ? undefined : newCurrentAuthorData(data) },
+    // TODO Remove the any by having interfaces have a __typename that pacifies mutation type unions
+    result: { data: data instanceof Error ? undefined : (newCurrentAuthorData(data) as any) },
     error: data instanceof Error ? data : undefined,
   };
 }
@@ -446,4 +449,6 @@ export function newCurrentAuthorResponse(
       data?: Q;
     };
     error?: Error;
+    // Note this only works if using Homebound's better-apollo-mocked-provider
+    requestedCount?: number;
   };

--- a/src/index.ts
+++ b/src/index.ts
@@ -84,7 +84,8 @@ function newOperationFactory(schema: GraphQLSchema, def: OperationDefinitionNode
     ): MockedResponse<${name}${operation}Variables, ${name}${operation}> {
       return {
         request: { query: ${name}Document, ${hasVariables ? "variables, " : ""} },
-        result: { data: data instanceof Error ? undefined : new${name}Data(data) },
+        // TODO Remove the any by having interfaces have a __typename that pacifies mutation type unions
+        result: { data: data instanceof Error ? undefined : new${name}Data(data) as any },
         error: data instanceof Error ? data : undefined,
       };
     }`;


### PR DESCRIPTION
When using apollo queries, queries into an interface generate types
like:

```
        & { commentable: (
          { __typename: 'Bill' }
          & CommentFeed_Bill_Fragment
        ) | (
          { __typename: 'Task' }
          & CommentFeed_Task_Fragment
        ) | (
          { __typename: 'Project' }
          & CommentFeed_Project_Fragment
        ) | (
          { __typename: 'ProjectItem' }
          & CommentFeed_ProjectItem_Fragment
        ) | (
          { __typename: 'Invoice' }
          & CommentFeed_Invoice_Fragment
        ) }
```

Against a CommentStream that looks like:

```
export type CommentStream = {
  commentable: Commentable;
};
```

However, because `Commentable` is just:

```
export type Commentable = {
  id: Scalars['ID'];
  commentStreams: CommentStreams;
  followers: Array<InternalUser>;
};
```

I.e. there is no `__typename`, the tsc compiler doesn't like our
response factory returning the `Commentable` when the mutation
"want's something more specific".

The best fix for this is adding a `__typename` to `Commentable` but
this involves patching graphql-code-generator which is generally a
PITA to do.

Given this is internal/generated code that we "trust to be right",
let's just add the `as any` for on and we can revisit.

Note that an additional wrinkle is that internal-frontend is not using
`nonOptionalTypeNames`, i.e. it has `__typename?` on the types, and so
was working just fine (the mutation's union type didn't complain when
typed against the `__typename`-less `Commentable`).

However HOP uses `union` types which seem to magically de-optionalize
`__typename`s _only_ for the fragments that touch unions, probably to
help with exhausitive checking. This is "fine" but it leads to a mess
a mess of "some types need `__typename` / some don't" --> "1000s of compile
errors". So we turn on `nonOptionalTypeNames` to avoid that.

Eventually we should just stop using graphql-code-generator; they have
too many options that play off each other in various unintended ways,
vs. having opinionated output that just works.