### PR TITLE
chore: update NPM contexts

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,21 +1,29 @@
 version: 2.1
 
 orbs:
-  node: circleci/node@1.1.4
+  node: circleci/node@5.0.0
+
+node-image: &node-image
+  image: cimg/node:16.4.0
+  auth:
+    username: $DOCKERHUB_USERNAME
+    password: $DOCKERHUB_ACCESS_TOKEN
 
 workflows:
   version: 2
   workflow:
     jobs:
       - build:
-          context: npm
-          filters:
-            branches:
-              ignore:
-                - main
-      - build:
-          context: npm
-          publish: true
+          context:
+            - npm-readonly
+            - dockerhub
+      - publish:
+          context:
+            - npm-publish
+            - dockerhub
+            - github
+          requires:
+            - build
           filters:
             branches:
               only:
@@ -23,22 +31,24 @@ workflows:
 
 jobs:
   build:
-    parameters:
-      publish:
-        type: boolean
-        default: false
     docker:
-      - image: circleci/node:12.7
+      - <<: *node-image
     working_directory: ~/project
     steps:
       - checkout
-      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" > .npmrc'
-      - node/with-cache:
-          steps:
-            - run: npm install
+      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc'
+      - node/install-packages
       - run: npm run build
-      - when:
-          condition: <<parameters.publish>>
-          steps:
-            - run: ./bump.sh package.json
-            - run: npm publish
+      - run: npm run test
+
+  publish:
+    docker:
+      - <<: *node-image
+    working_directory: ~/project
+    steps:
+      - checkout
+      - run: 'echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> .npmrc'
+      - node/install-packages
+      - run: npm run build
+      - run: ./bump.sh package.json
+      - run: npm publish

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "types": "./build/",
   "scripts": {
     "build": "rm -rf build; ./node_modules/.bin/tsc",
+    "test": "jest",
     "prepare": "npm run build",
     "format": "prettier --write 'src/**/*.{ts,js,tsx,jsx}'",
     "graphql-codegen": "graphql-codegen --config ./integration/graphql-codegen.yml"


### PR DESCRIPTION
https://app.shortcut.com/homebound-team/story/13496/regenerate-ci-npm-tokens

This PR updates the CircleCI config to use two distinct `npm` contexts (read-only and publish). This reduces the risk of accidentally publishing in a step that should not. Additionally, it uses a new automation-type token that allows us to enable 2-Factor Auth for login but not for the publishing token.

Once I transition our projects, I will delete the old `npm` context.